### PR TITLE
feat: Added update-template action, resolves #19

### DIFF
--- a/{{cookiecutter.package_name}}/.github/workflows/pre-commit.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/pre-commit.yml
@@ -26,5 +26,4 @@ jobs:
           committer_email: ${{ secrets.CHANGELOG_EMAIL }}
           commit_prefix: "chore: "
           commit_message: "apply auto-fixes from the pre-commit checks"
-
 {% endraw %}

--- a/{{cookiecutter.package_name}}/.github/workflows/release.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/release.yml
@@ -36,5 +36,4 @@ jobs:
           GIT_COMMITTER_NAME: ${{ secrets.IMM_BOT_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.IMM_BOT_EMAIL }}
           GITHUB_TOKEN: ${{ secrets.IMM_BOT_TOKEN }}
-
 {% endraw %}

--- a/{{cookiecutter.package_name}}/.github/workflows/update-store-listing.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/update-store-listing.yml
@@ -23,5 +23,4 @@ jobs:
         env:
           IMM_STORE_TOKEN: ${{ secrets.IMM_STORE_TOKEN }}
           IMM_STORE_URL: ${{ secrets.IMM_STORE_URL }}
-
 {% endraw %}

--- a/{{cookiecutter.package_name}}/.github/workflows/update-template.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/update-template.yml
@@ -1,0 +1,36 @@
+{% raw %}
+on:
+  schedule:
+    - cron: 0 0 1 * *
+  workflow_dispatch:
+
+name: Update template
+jobs:
+  update-template:
+    strategy:
+      matrix:
+        python: [3.8]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          pip install cruft pre-commit
+      - name: Update template
+        uses: technote-space/create-pr-action@v2
+        with:
+          EXECUTE_COMMANDS: |
+            pre-commit run --all-files
+            cruft update -y
+          COMMIT_MESSAGE: "chore: update template"
+          COMMIT_NAME: ${{ secrets.IMM_BOT_NAME }}
+          COMMIT_EMAIL: ${{ secrets.IMM_BOT_EMAIL }}
+          GITHUB_TOKEN: ${{ secrets.IMM_BOT_TOKEN }}
+          PR_BRANCH_NAME: "chore/${PR_ID}-update-template"
+          PR_TITLE: "chore: update template"
+{% endraw %}

--- a/{{cookiecutter.package_name}}/.github/workflows/upload-packages.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/upload-packages.yml
@@ -37,5 +37,4 @@ jobs:
           TWINE_REPOSITORY_URL: https://pip.immsuite.cloud
           TWINE_USERNAME: ${{ secrets.PRIVATE_PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PRIVATE_PYPI_PASSWORD }}
-
 {% endraw %}


### PR DESCRIPTION
Next time the template is updated for an extension, this action will be added.

This will attempt to run `cruft update` every month and create a PR with whatever it spits out.

It's a little bit rusty chainsaw in approach, and will require a decent bit of human oversight/probably some tweaks to behaviour, but at least it's likely to remind us to update the extensions